### PR TITLE
feat: editable keyword groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
         <div class="weights" id="weights">
           <!-- sliders injected here -->
         </div>
+        <button class="btn alt" id="addGroup" style="margin-top:10px">Add Group</button>
       </div>
 
       <div class="section" style="display:flex; gap:10px; flex-wrap:wrap">

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
 // --- Keyword groups & default weights ---
-const GROUPS = [
+const DEFAULT_GROUPS = [
   { key:"dotnet", label:".NET stack (.NET, C#, ASP.NET)", patterns:[".net","c#","asp.net","aspnet","entity framework","ef core"], weight:8 },
   { key:"java", label:"Java stack (Java, Spring)", patterns:[" java ","spring","spring boot"], weight:2 },
   { key:"micro", label:"Microservices", patterns:["microservice","micro-services","micro services"], weight:3 },
@@ -11,7 +11,20 @@ const GROUPS = [
   { key:"edu", label:"Education (Bachelor/CS)", patterns:["bachelor","b.sc","bsc","computer science","b.tech","btech"], weight:2 },
 ];
 
-const el = id => document.getElementById(id);
+let groups = [];
+try {
+  groups = JSON.parse(localStorage.getItem('groups') || '[]');
+} catch(e) { groups = []; }
+if (!groups.length) {
+  groups = JSON.parse(JSON.stringify(DEFAULT_GROUPS));
+  saveGroups();
+}
+
+function saveGroups(){
+  localStorage.setItem('groups', JSON.stringify(groups));
+}
+
+const el = id => typeof document !== 'undefined' ? document.getElementById(id) : null;
 const fileEl = el('file');
 const rankBtn = el('rankBtn');
 const previewBtn = el('previewBtn');
@@ -29,43 +42,60 @@ let rows = [];         // raw records
 let headers = [];      // csv headers
 let ranked = [];       // ranked rows with score & reason
 
-// Build weights UI
+// Build group UI
 const weightsWrap = el('weights');
-function renderWeightSliders(){
+function renderGroupsUI(){
+  if(!weightsWrap) return;
   weightsWrap.innerHTML = '';
-  GROUPS.forEach(g=>{
-    const id = 'w_'+g.key;
+  groups.forEach((g,i)=>{
     const block = document.createElement('div');
-    block.className = 'slider card section';
+    block.className = 'group-card card section';
     block.innerHTML = `
-        <div style="font-weight:600">${g.label}</div>
-        <input type="range" id="${id}" min="0" max="12" step="1" value="${g.weight}">
-        <div class="small">Weight: <span class="badge" id="${id}_v">${g.weight}</span></div>
+        <input type="text" class="grp-label" placeholder="Label" value="${g.label}">
+        <input type="text" class="grp-patterns" placeholder="pattern1, pattern2" value="${g.patterns.join(', ')}">
+        <input type="range" class="grp-weight" min="0" max="12" step="1" value="${g.weight}">
+        <div class="small">Weight: <span class="badge">${g.weight}</span></div>
+        <button class="btn warn remove">Remove</button>
       `;
     weightsWrap.appendChild(block);
-    const slider = block.querySelector('#'+id);
-    const out = block.querySelector('#'+id+'_v');
-    slider.addEventListener('input',()=>{ out.textContent = slider.value; g.weight = Number(slider.value); });
+    const labelInput = block.querySelector('.grp-label');
+    labelInput.addEventListener('input',()=>{ g.label = labelInput.value; saveGroups(); });
+    const patternsInput = block.querySelector('.grp-patterns');
+    patternsInput.addEventListener('input',()=>{ g.patterns = patternsInput.value.split(',').map(p=>p.trim().toLowerCase()).filter(Boolean); saveGroups(); });
+    const slider = block.querySelector('.grp-weight');
+    const out = block.querySelector('.badge');
+    slider.addEventListener('input',()=>{ g.weight = Number(slider.value); out.textContent = slider.value; saveGroups(); });
+    block.querySelector('.remove').addEventListener('click',()=>{ groups.splice(i,1); renderGroupsUI(); saveGroups(); });
   });
 }
-renderWeightSliders();
+renderGroupsUI();
+const addGroupBtn = el('addGroup');
+if(addGroupBtn) addGroupBtn.addEventListener('click',()=>{
+  groups.push({ label:'', patterns:[], weight:0 });
+  renderGroupsUI();
+  saveGroups();
+});
 
 // Presets
-el('presetNet').addEventListener('click',()=>{
-  GROUPS.find(g=>g.key==='dotnet').weight = 10;
-  GROUPS.find(g=>g.key==='java').weight = 2;
-  GROUPS.find(g=>g.key==='micro').weight = 3;
-  GROUPS.find(g=>g.key==='db').weight = 3;
-  GROUPS.find(g=>g.key==='fe').weight = 2;
-  GROUPS.find(g=>g.key==='devops').weight = 2;
-  GROUPS.find(g=>g.key==='cloud').weight = 3;
-  GROUPS.find(g=>g.key==='support').weight = 3;
-  GROUPS.find(g=>g.key==='edu').weight = 2;
-  renderWeightSliders();
+const presetNetBtn = el('presetNet');
+if(presetNetBtn) presetNetBtn.addEventListener('click',()=>{
+  groups.find(g=>g.key==='dotnet').weight = 10;
+  groups.find(g=>g.key==='java').weight = 2;
+  groups.find(g=>g.key==='micro').weight = 3;
+  groups.find(g=>g.key==='db').weight = 3;
+  groups.find(g=>g.key==='fe').weight = 2;
+  groups.find(g=>g.key==='devops').weight = 2;
+  groups.find(g=>g.key==='cloud').weight = 3;
+  groups.find(g=>g.key==='support').weight = 3;
+  groups.find(g=>g.key==='edu').weight = 2;
+  renderGroupsUI();
+  saveGroups();
 });
-el('presetBalanced').addEventListener('click',()=>{
-  GROUPS.forEach(g=> g.weight = {dotnet:8, java:3, micro:3, db:2, fe:2, devops:2, cloud:2, support:2, edu:2}[g.key] || 2);
-  renderWeightSliders();
+const presetBalancedBtn = el('presetBalanced');
+if(presetBalancedBtn) presetBalancedBtn.addEventListener('click',()=>{
+  groups.forEach(g=> g.weight = {dotnet:8, java:3, micro:3, db:2, fe:2, devops:2, cloud:2, support:2, edu:2}[g.key] || 2);
+  renderGroupsUI();
+  saveGroups();
 });
 
 function guessMapping() {
@@ -89,7 +119,7 @@ function guessMapping() {
   });
 }
 
-fileEl.addEventListener('change', (e)=>{
+if(fileEl) fileEl.addEventListener('change', (e)=>{
   const f = e.target.files?.[0];
   if(!f) return;
   statusEl.textContent = 'Parsing…';
@@ -120,10 +150,10 @@ function makeTextBlob(r){
   return (' '+parts.join(' ')+' ').toLowerCase(); // padded for exact-ish word checks
 }
 
-function scoreRow(r){
-  const text = makeTextBlob(r);
+function scoreRow(r, textOverride){
+  const text = textOverride ?? makeTextBlob(r);
   let score = 0; const hits=[];
-  GROUPS.forEach(g=>{
+  groups.forEach(g=>{
     const matched = g.patterns.some(p=> text.includes(p));
     if(matched){ score += g.weight; hits.push(g.label); }
   });
@@ -201,6 +231,10 @@ function exportCSV(){
   URL.revokeObjectURL(url);
 }
 
-rankBtn.addEventListener('click', ()=> rank(false));
-previewBtn.addEventListener('click', ()=> rank(true));
-exportBtn.addEventListener('click', exportCSV);
+if(rankBtn) rankBtn.addEventListener('click', ()=> rank(false));
+if(previewBtn) previewBtn.addEventListener('click', ()=> rank(true));
+if(exportBtn) exportBtn.addEventListener('click', exportCSV);
+
+if (typeof module !== 'undefined') {
+  module.exports = { groups, saveGroups, renderGroupsUI, scoreRow };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "candidate-ranker-ui",
+  "version": "1.0.0",
+  "description": "",
+  "main": "main.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/style.css
+++ b/style.css
@@ -30,6 +30,9 @@ th{color:#bcd0ea; text-align:left; position:sticky; top:0; background:var(--card
 .weights{display:grid; grid-template-columns:repeat(4,1fr); gap:12px}
 @media (max-width:900px){.weights{grid-template-columns:1fr 1fr}}
 .slider{display:grid; gap:6px}
+.group-card{display:grid; gap:6px}
+.group-card .remove{margin-top:6px}
+#addGroup{margin-top:12px}
 input[type=range]{width:100%}
 .badge{padding:2px 8px; border-radius:999px; background:#142341; color:#cfe2ff; font-size:12px}
 .muted{color:var(--muted)}

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+function setup(){
+  global.localStorage = {
+    data:{},
+    setItem(k,v){ this.data[k]=v; },
+    getItem(k){ return this.data[k]; },
+    removeItem(k){ delete this.data[k]; }
+  };
+  delete require.cache[require.resolve('../main.js')];
+  return require('../main.js');
+}
+
+test('scoreRow uses current groups', () => {
+  const main = setup();
+  main.groups.length = 0;
+  main.groups.push({ label:'Foo', patterns:['foo'], weight:5 });
+  const res1 = main.scoreRow(null, 'foo is here');
+  assert.strictEqual(res1.score, 5);
+  assert.strictEqual(res1.reason, 'Foo');
+
+  main.groups[0].patterns = ['bar'];
+  main.groups[0].weight = 2;
+  const res2 = main.scoreRow(null, 'bar appears');
+  assert.strictEqual(res2.score, 2);
+  assert.strictEqual(res2.reason, 'Foo');
+});
+
+test('saveGroups persists changes', () => {
+  const main = setup();
+  const initial = main.groups.length;
+  main.groups.push({ label:'', patterns:[], weight:0 });
+  main.saveGroups();
+  const stored = JSON.parse(global.localStorage.getItem('groups'));
+  assert.strictEqual(stored.length, initial + 1);
+});


### PR DESCRIPTION
## Summary
- replace fixed weight sliders with editable keyword group cards
- add button to create and remove keyword groups and persist changes in localStorage
- score rows against current keyword groups
- expose group helpers for testing and add Node-based unit tests

## Testing
- `node --check main.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4cd4428dc832f84371a11df45f353