### PR TITLE
Refactor UI to React and expose core logic

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,0 +1,209 @@
+const { useState, useEffect } = React;
+
+function GroupCard({ group, index, onChange, onRemove }) {
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    let updated = value;
+    if (name === 'patterns') {
+      updated = value.split(',').map(p => p.trim().toLowerCase()).filter(Boolean);
+    }
+    if (name === 'weight') {
+      updated = Number(value);
+    }
+    onChange(index, { ...group, [name]: updated });
+  };
+
+  return (
+    <div className="group-card card section">
+      <input type="text" name="label" placeholder="Label" value={group.label} onChange={handleChange} />
+      <input type="text" name="patterns" placeholder="pattern1, pattern2" value={group.patterns.join(', ')} onChange={handleChange} />
+      <input type="range" name="weight" min="0" max="12" step="1" value={group.weight} onChange={handleChange} />
+      <div className="small">Weight: <span className="badge">{group.weight}</span></div>
+      <button className="btn warn remove" onClick={() => onRemove(index)}>Remove</button>
+    </div>
+  );
+}
+
+function App() {
+  const [groups, setGroups] = useState(window.main.groups);
+  const [rows, setRows] = useState([]);
+  const [headers, setHeaders] = useState([]);
+  const [ranked, setRanked] = useState([]);
+  const [status, setStatus] = useState('');
+  const [topN, setTopN] = useState(30);
+  const [colName, setColName] = useState('');
+  const [colLinkedIn, setColLinkedIn] = useState('');
+  const [colATS, setColATS] = useState('');
+  const [colScan, setColScan] = useState([]);
+
+  useEffect(() => {
+    window.main.groups = groups;
+    window.main.saveGroups();
+  }, [groups]);
+
+  const updateGroup = (i, g) => setGroups(gs => gs.map((grp, idx) => idx === i ? g : grp));
+  const removeGroup = (i) => setGroups(gs => gs.filter((_, idx) => idx !== i));
+  const addGroup = () => setGroups(gs => [...gs, { label: '', patterns: [], weight: 0 }]);
+
+  const handleFile = e => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setStatus('Parsing…');
+    Papa.parse(f, {
+      header: true,
+      skipEmptyLines: true,
+      complete: res => {
+        setRows(res.data);
+        const hdr = res.meta.fields || Object.keys(res.data[0] || {});
+        setHeaders(hdr);
+        guessMapping(hdr);
+        setStatus(`Loaded ${res.data.length} rows · ${hdr.length} columns`);
+      },
+      error: err => setStatus('Parse error: ' + err)
+    });
+  };
+
+  const guessMapping = hdr => {
+    const find = subs => hdr.find(h => subs.some(s => h.toLowerCase().includes(s))) || hdr[0] || '';
+    setColName(find(['name']));
+    setColLinkedIn(find(['linkedin']));
+    setColATS(find(['candidate url', 'ats', 'comeet', 'url']));
+    const scanLikely = ["skills", "current position", "past position", "education", "degree", "languages"];
+    setColScan(hdr.filter(h => scanLikely.some(s => h.toLowerCase().includes(s))));
+  };
+
+  const makeTextBlob = r => {
+    const parts = colScan.map(c => String(r[c] || ''));
+    return (' ' + parts.join(' ') + ' ').toLowerCase();
+  };
+
+  const rank = topOnly => {
+    if (!rows.length) { setStatus('Please upload a CSV first.'); return; }
+    const rankedRows = rows.map(r => {
+      const { score, reason } = window.main.scoreRow(null, makeTextBlob(r));
+      return { ...r, __score: score, __reason: reason, __name: r[colName] || '', __li: r[colLinkedIn] || '', __ats: r[colATS] || '' };
+    }).sort((a, b) => b.__score - a.__score);
+    const out = topOnly ? rankedRows.slice(0, 10) : rankedRows.slice(0, Math.max(1, Number(topN)));
+    setRanked(out);
+    setStatus(`${out.length} shown (Top ${topOnly ? 10 : topN}) of ${rows.length}`);
+  };
+
+  const exportCSV = () => {
+    if (!ranked.length) return;
+    const out = ranked.map(r => ({
+      Score: r.__score,
+      Name: r.__name,
+      LinkedIn: r.__li,
+      CandidateURL: r.__ats,
+      Why: r.__reason
+    }));
+    const csv = Papa.unparse(out);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = `ranked_candidates_${new Date().toISOString().slice(0,10)}.csv`;
+    document.body.appendChild(a); a.click(); document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const presetNet = () => {
+    const weights = { dotnet: 10, java: 2, micro: 3, db: 3, fe: 2, devops: 2, cloud: 3, support: 3, edu: 2 };
+    setGroups(gs => gs.map(g => ({ ...g, weight: weights[g.key] ?? g.weight })));
+  };
+
+  const presetBalanced = () => {
+    const weights = { dotnet: 8, java: 3, micro: 3, db: 2, fe: 2, devops: 2, cloud: 2, support: 2, edu: 2 };
+    setGroups(gs => gs.map(g => ({ ...g, weight: weights[g.key] ?? g.weight })));
+  };
+
+  return (
+    <div className="wrap">
+      <h1>Candidate Ranker <span className="badge">HR Friendly</span></h1>
+      <div className="sub">Upload a candidate CSV, set weights, and export a ranked Top N. Runs 100% in your browser (no server).</div>
+      <div className="card">
+        <div className="section row">
+          <div>
+            <label>Upload CSV (export from Comeet / ATS)</label>
+            <input type="file" accept=".csv" onChange={handleFile} />
+            <div className="small" style={{ marginTop: '8px' }}>Detected columns will appear below so you can map them.</div>
+          </div>
+          <div>
+            <label>Top N to keep</label>
+            <input type="number" min="1" value={topN} onChange={e => setTopN(e.target.value)} />
+            <div className="small">Default is 30</div>
+          </div>
+        </div>
+
+        <div className="section">
+          <div className="grid">
+            <div>
+              <label>Column: <b>Name</b></label>
+              <select value={colName} onChange={e => setColName(e.target.value)}>{headers.map(h => <option key={h}>{h}</option>)}</select>
+            </div>
+            <div>
+              <label>Column: <b>LinkedIn URL</b></label>
+              <select value={colLinkedIn} onChange={e => setColLinkedIn(e.target.value)}>{headers.map(h => <option key={h}>{h}</option>)}</select>
+            </div>
+            <div>
+              <label>Column: <b>ATS Candidate URL</b></label>
+              <select value={colATS} onChange={e => setColATS(e.target.value)}>{headers.map(h => <option key={h}>{h}</option>)}</select>
+            </div>
+            <div>
+              <label>Column(s) scanned for keywords (hold <span className="kbd">Ctrl</span> to select multiple)</label>
+              <select multiple size="6" value={colScan} onChange={e => setColScan(Array.from(e.target.selectedOptions).map(o => o.value))}>
+                {headers.map(h => <option key={h}>{h}</option>)}
+              </select>
+              <div className="small">Tip: include <i>Skills</i>, <i>Current position</i>, <i>Past position</i>, <i>Education level</i>, <i>Degree</i>.</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="section">
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap', marginBottom: '10px' }}>
+            <span className="pill">Preset: <button className="btn alt" onClick={presetNet}>Favor .NET</button> <button className="btn alt" onClick={presetBalanced}>Balanced</button></span>
+            <span className="small">Adjust sliders to change scoring weights. Total score is the sum of matched keyword groups.</span>
+          </div>
+          <div className="weights">
+            {groups.map((g, i) => <GroupCard key={i} group={g} index={i} onChange={updateGroup} onRemove={removeGroup} />)}
+          </div>
+          <button className="btn alt" id="addGroup" style={{ marginTop: '10px' }} onClick={addGroup}>Add Group</button>
+        </div>
+
+        <div className="section" style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+          <button className="btn" onClick={() => rank(false)}>Rank Candidates</button>
+          <button className="btn alt" onClick={() => rank(true)}>Preview 10</button>
+          <button className="btn warn" onClick={exportCSV} disabled={!ranked.length}>Export Ranked CSV</button>
+          <span className="small">{status}</span>
+        </div>
+
+        {ranked.length > 0 && (
+          <div className="section" id="tableWrap" style={{ display: 'block' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+              <div className="pill"><span>Results</span> <span id="resultCount">{ranked.length} shown</span></div>
+            </div>
+            <div style={{ overflow: 'auto', maxHeight: '60vh' }}>
+              <table id="tbl">
+                <thead><tr><th>Score</th><th>Name</th><th>LinkedIn</th><th>Candidate URL</th><th>Why (matched keywords)</th></tr></thead>
+                <tbody>
+                  {ranked.map((r, i) => (
+                    <tr key={i}>
+                      <td><span className="score">{r.__score}</span></td>
+                      <td>{r.__name}</td>
+                      <td>{r.__li && <a href={r.__li} target="_blank">LinkedIn</a>}</td>
+                      <td>{r.__ats && <a href={r.__ats} target="_blank">Open in ATS</a>}</td>
+                      <td><span className="small">{r.__reason}</span></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
+      <p className="small muted" style={{ marginTop: '14px' }}>CSV never leaves your machine. Scoring is keyword-based and explainable. Edit weights to match your criteria.</p>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# candidate-ranker-ui
+# Candidate Ranker UI
+
+This project provides a small in-browser tool for ranking candidates from a CSV export. The interface is now built with **React** and runs entirely on the client without any server component.
+
+## Development
+
+The app is intentionally lightweight and does not use a bundler. React and Babel are loaded from CDNs at runtime. To work on the project, simply open `index.html` in a browser.
+
+## Testing
+
+Core scoring logic is separated in `main.js` and can be tested with Node:
+
+```bash
+npm test
+```
+

--- a/index.html
+++ b/index.html
@@ -4,83 +4,20 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Candidate Ranker – HR Friendly</title>
-  <!-- Papa Parse for CSV parsing -->
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css" />
+  <!-- React from CDN for a lightweight setup -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
 </head>
 <body>
-  <div class="wrap">
-    <h1>Candidate Ranker <span class="badge">HR Friendly</span></h1>
-    <div class="sub">Upload a candidate CSV, set weights, and export a ranked Top N. Runs 100% in your browser (no server).</div>
+  <div id="root"></div>
 
-    <div class="card">
-      <div class="section row">
-        <div>
-          <label>Upload CSV (export from Comeet / ATS)</label>
-          <input id="file" type="file" accept=".csv" />
-          <div class="small" style="margin-top:8px">Detected columns will appear below so you can map them.</div>
-        </div>
-        <div>
-          <label>Top N to keep</label>
-          <input id="topN" type="number" min="1" value="30" />
-          <div class="small">Default is 30</div>
-        </div>
-      </div>
-
-      <div class="section">
-        <div class="grid">
-          <div>
-            <label>Column: <b>Name</b></label>
-            <select id="colName"></select>
-          </div>
-          <div>
-            <label>Column: <b>LinkedIn URL</b></label>
-            <select id="colLinkedIn"></select>
-          </div>
-          <div>
-            <label>Column: <b>ATS Candidate URL</b></label>
-            <select id="colATS"></select>
-          </div>
-          <div>
-            <label>Column(s) scanned for keywords (hold <span class="kbd">Ctrl</span> to select multiple)</label>
-            <select id="colScan" multiple size="6"></select>
-            <div class="small">Tip: include <i>Skills</i>, <i>Current position</i>, <i>Past position</i>, <i>Education level</i>, <i>Degree</i>.</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="section">
-        <div style="display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin-bottom:10px">
-          <span class="pill">Preset: <button class="btn alt" id="presetNet">Favor .NET</button> <button class="btn alt" id="presetBalanced">Balanced</button></span>
-          <span class="small">Adjust sliders to change scoring weights. Total score is the sum of matched keyword groups.</span>
-        </div>
-        <div class="weights" id="weights">
-          <!-- sliders injected here -->
-        </div>
-        <button class="btn alt" id="addGroup" style="margin-top:10px">Add Group</button>
-      </div>
-
-      <div class="section" style="display:flex; gap:10px; flex-wrap:wrap">
-        <button class="btn" id="rankBtn">Rank Candidates</button>
-        <button class="btn alt" id="previewBtn">Preview 10</button>
-        <button class="btn warn" id="exportBtn" disabled>Export Ranked CSV</button>
-        <span class="small" id="status"></span>
-      </div>
-
-      <div class="section" id="tableWrap" style="display:none">
-        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px">
-          <div class="pill"><span>Results</span> <span id="resultCount"></span></div>
-          <div class="small">Sorted by <b>Score</b> desc. Click column headers to sort locally.</div>
-        </div>
-        <div style="overflow:auto; max-height:60vh">
-          <table id="tbl"><thead></thead><tbody></tbody></table>
-        </div>
-      </div>
-    </div>
-
-    <p class="small muted" style="margin-top:14px">CSV never leaves your machine. Scoring is keyword-based and explainable. Edit weights to match your criteria.</p>
-  </div>
-
-<script src="main.js"></script>
+  <!-- Logic module shared between browser and tests -->
+  <script src="main.js"></script>
+  <!-- React application -->
+  <script type="text/babel" src="App.jsx"></script>
 </body>
 </html>
+

--- a/main.js
+++ b/main.js
@@ -1,240 +1,59 @@
-// --- Keyword groups & default weights ---
+// Core scoring logic and persistence for keyword groups.
+// This file deliberately avoids DOM access so it can run in both
+// browser and Node test environments.
+
+// Default keyword groups and weights
 const DEFAULT_GROUPS = [
-  { key:"dotnet", label:".NET stack (.NET, C#, ASP.NET)", patterns:[".net","c#","asp.net","aspnet","entity framework","ef core"], weight:8 },
-  { key:"java", label:"Java stack (Java, Spring)", patterns:[" java ","spring","spring boot"], weight:2 },
-  { key:"micro", label:"Microservices", patterns:["microservice","micro-services","micro services"], weight:3 },
-  { key:"db", label:"Databases (SQL/NoSQL)", patterns:[" sql ","database","postgres","mysql","mssql","nosql","mongodb","cosmos","dynamodb"], weight:2 },
-  { key:"fe", label:"Front-end (React/Angular/Vue)", patterns:["react","angular","vue"], weight:2 },
-  { key:"devops", label:"CI/CD & Tools (Bitbucket/Jenkins/Pipelines)", patterns:["bitbucket","jenkins","pipeline","ci/cd","cicd","github actions","azure devops"], weight:2 },
-  { key:"cloud", label:"Cloud & Messaging (AWS/Azure/RabbitMQ/Couchbase)", patterns:["aws","azure","gcp","cloud","rabbitmq","couchbase","sqs","sns","kafka"], weight:2 },
-  { key:"support", label:"Support & Debugging", patterns:["support","tier-3","tier3","debug","troubleshoot","incident"], weight:2 },
-  { key:"edu", label:"Education (Bachelor/CS)", patterns:["bachelor","b.sc","bsc","computer science","b.tech","btech"], weight:2 },
+  { key: "dotnet", label: ".NET stack (.NET, C#, ASP.NET)", patterns: [".net", "c#", "asp.net", "aspnet", "entity framework", "ef core"], weight: 8 },
+  { key: "java", label: "Java stack (Java, Spring)", patterns: [" java ", "spring", "spring boot"], weight: 2 },
+  { key: "micro", label: "Microservices", patterns: ["microservice", "micro-services", "micro services"], weight: 3 },
+  { key: "db", label: "Databases (SQL/NoSQL)", patterns: [" sql ", "database", "postgres", "mysql", "mssql", "nosql", "mongodb", "cosmos", "dynamodb"], weight: 2 },
+  { key: "fe", label: "Front-end (React/Angular/Vue)", patterns: ["react", "angular", "vue"], weight: 2 },
+  { key: "devops", label: "CI/CD & Tools (Bitbucket/Jenkins/Pipelines)", patterns: ["bitbucket", "jenkins", "pipeline", "ci/cd", "cicd", "github actions", "azure devops"], weight: 2 },
+  { key: "cloud", label: "Cloud & Messaging (AWS/Azure/RabbitMQ/Couchbase)", patterns: ["aws", "azure", "gcp", "cloud", "rabbitmq", "couchbase", "sqs", "sns", "kafka"], weight: 2 },
+  { key: "support", label: "Support & Debugging", patterns: ["support", "tier-3", "tier3", "debug", "troubleshoot", "incident"], weight: 2 },
+  { key: "edu", label: "Education (Bachelor/CS)", patterns: ["bachelor", "b.sc", "bsc", "computer science", "b.tech", "btech"], weight: 2 }
 ];
 
+// Load existing groups from localStorage if possible
 let groups = [];
 try {
   groups = JSON.parse(localStorage.getItem('groups') || '[]');
-} catch(e) { groups = []; }
+} catch (e) {
+  groups = [];
+}
+
+function saveGroups() {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('groups', JSON.stringify(groups));
+  }
+}
+
 if (!groups.length) {
   groups = JSON.parse(JSON.stringify(DEFAULT_GROUPS));
   saveGroups();
 }
 
-function saveGroups(){
-  localStorage.setItem('groups', JSON.stringify(groups));
-}
-
-const el = id => typeof document !== 'undefined' ? document.getElementById(id) : null;
-const fileEl = el('file');
-const rankBtn = el('rankBtn');
-const previewBtn = el('previewBtn');
-const exportBtn = el('exportBtn');
-const statusEl = el('status');
-const tableWrap = el('tableWrap');
-const resultCount = el('resultCount');
-
-const colName = el('colName');
-const colLinkedIn = el('colLinkedIn');
-const colATS = el('colATS');
-const colScan = el('colScan');
-
-let rows = [];         // raw records
-let headers = [];      // csv headers
-let ranked = [];       // ranked rows with score & reason
-
-// Build group UI
-const weightsWrap = el('weights');
-function renderGroupsUI(){
-  if(!weightsWrap) return;
-  weightsWrap.innerHTML = '';
-  groups.forEach((g,i)=>{
-    const block = document.createElement('div');
-    block.className = 'group-card card section';
-    block.innerHTML = `
-        <input type="text" class="grp-label" placeholder="Label" value="${g.label}">
-        <input type="text" class="grp-patterns" placeholder="pattern1, pattern2" value="${g.patterns.join(', ')}">
-        <input type="range" class="grp-weight" min="0" max="12" step="1" value="${g.weight}">
-        <div class="small">Weight: <span class="badge">${g.weight}</span></div>
-        <button class="btn warn remove">Remove</button>
-      `;
-    weightsWrap.appendChild(block);
-    const labelInput = block.querySelector('.grp-label');
-    labelInput.addEventListener('input',()=>{ g.label = labelInput.value; saveGroups(); });
-    const patternsInput = block.querySelector('.grp-patterns');
-    patternsInput.addEventListener('input',()=>{ g.patterns = patternsInput.value.split(',').map(p=>p.trim().toLowerCase()).filter(Boolean); saveGroups(); });
-    const slider = block.querySelector('.grp-weight');
-    const out = block.querySelector('.badge');
-    slider.addEventListener('input',()=>{ g.weight = Number(slider.value); out.textContent = slider.value; saveGroups(); });
-    block.querySelector('.remove').addEventListener('click',()=>{ groups.splice(i,1); renderGroupsUI(); saveGroups(); });
-  });
-}
-renderGroupsUI();
-const addGroupBtn = el('addGroup');
-if(addGroupBtn) addGroupBtn.addEventListener('click',()=>{
-  groups.push({ label:'', patterns:[], weight:0 });
-  renderGroupsUI();
-  saveGroups();
-});
-
-// Presets
-const presetNetBtn = el('presetNet');
-if(presetNetBtn) presetNetBtn.addEventListener('click',()=>{
-  groups.find(g=>g.key==='dotnet').weight = 10;
-  groups.find(g=>g.key==='java').weight = 2;
-  groups.find(g=>g.key==='micro').weight = 3;
-  groups.find(g=>g.key==='db').weight = 3;
-  groups.find(g=>g.key==='fe').weight = 2;
-  groups.find(g=>g.key==='devops').weight = 2;
-  groups.find(g=>g.key==='cloud').weight = 3;
-  groups.find(g=>g.key==='support').weight = 3;
-  groups.find(g=>g.key==='edu').weight = 2;
-  renderGroupsUI();
-  saveGroups();
-});
-const presetBalancedBtn = el('presetBalanced');
-if(presetBalancedBtn) presetBalancedBtn.addEventListener('click',()=>{
-  groups.forEach(g=> g.weight = {dotnet:8, java:3, micro:3, db:2, fe:2, devops:2, cloud:2, support:2, edu:2}[g.key] || 2);
-  renderGroupsUI();
-  saveGroups();
-});
-
-function guessMapping() {
-  const opts = headers.map(h=>`<option>${h}</option>`).join('');
-  [colName, colLinkedIn, colATS, colScan].forEach(sel=> sel.innerHTML = opts);
-
-  function selectIfContains(selectEl, substrings){
-    substrings = substrings.map(s=>s.toLowerCase());
-    const idx = headers.findIndex(h=> substrings.some(s=> h.toLowerCase().includes(s)));
-    if(idx>=0) selectEl.selectedIndex = idx;
-  }
-
-  selectIfContains(colName,["name"]);
-  selectIfContains(colLinkedIn,["linkedin"]);
-  selectIfContains(colATS,["candidate url","ats","comeet","url"]);
-
-  // Multi select defaults for scanning
-  const scanLikely = ["skills","current position","past position","education","degree","languages"];
-  Array.from(colScan.options).forEach(opt=>{
-    if (scanLikely.some(s=> opt.value.toLowerCase().includes(s))) opt.selected = true;
-  });
-}
-
-if(fileEl) fileEl.addEventListener('change', (e)=>{
-  const f = e.target.files?.[0];
-  if(!f) return;
-  statusEl.textContent = 'Parsing…';
-  Papa.parse(f, {
-    header:true,
-    skipEmptyLines:true,
-    complete: (res)=>{
-      rows = res.data;
-      headers = res.meta.fields || Object.keys(rows[0]||{});
-      guessMapping();
-      tableWrap.style.display='none';
-      exportBtn.disabled = true;
-      statusEl.textContent = `Loaded ${rows.length} rows · ${headers.length} columns`;
-    },
-    error: (err)=>{
-      statusEl.textContent = 'Parse error: '+err;
+// Score a text blob against current groups
+function scoreRow(_row, textOverride = '') {
+  const text = (textOverride || '').toLowerCase();
+  let score = 0; const hits = [];
+  groups.forEach(g => {
+    const matched = g.patterns.some(p => text.includes(p));
+    if (matched) {
+      score += g.weight;
+      hits.push(g.label);
     }
-  })
-});
-
-function getSelectedScanColumns(){
-  return Array.from(colScan.selectedOptions).map(o=>o.value);
-}
-
-function makeTextBlob(r){
-  const scanCols = getSelectedScanColumns();
-  const parts = scanCols.map(c=> String(r[c]||''));
-  return (' '+parts.join(' ')+' ').toLowerCase(); // padded for exact-ish word checks
-}
-
-function scoreRow(r, textOverride){
-  const text = textOverride ?? makeTextBlob(r);
-  let score = 0; const hits=[];
-  groups.forEach(g=>{
-    const matched = g.patterns.some(p=> text.includes(p));
-    if(matched){ score += g.weight; hits.push(g.label); }
   });
   return { score, reason: hits.join(' · ') };
 }
 
-function rank(topOnly=false){
-  if(!rows.length){ statusEl.textContent = 'Please upload a CSV first.'; return; }
-  const nameCol = colName.value; const liCol = colLinkedIn.value; const atsCol = colATS.value;
-
-  ranked = rows.map(r=>{
-    const {score, reason} = scoreRow(r);
-    return { ...r, __score:score, __reason:reason, __name:r[nameCol]||'', __li:r[liCol]||'', __ats:r[atsCol]||'' };
-  }).sort((a,b)=> b.__score - a.__score);
-
-  const topN = Math.max(1, Number(el('topN').value||30));
-  const view = topOnly ? ranked.slice(0,10) : ranked.slice(0, topN);
-  renderTable(view);
-
-  resultCount.textContent = `${view.length} shown (Top ${topOnly?10:topN}) of ${rows.length}`;
-  tableWrap.style.display='block';
-  exportBtn.disabled = false;
-}
-
-function renderTable(view){
-  const tbl = el('tbl');
-  const cols = ["__score","__name","__li","__ats","__reason"]; // always show these
-  // plus add a couple of helpful columns if they exist
-  const extras = ["Skills","Current position","Past position","Education level","Degree"].filter(h=> headers.includes(h));
-  const all = [...cols, ...extras];
-
-  const labels = {
-    "__score":"Score", "__name":"Name", "__li":"LinkedIn", "__ats":"Candidate URL", "__reason":"Why (matched keywords)"
-  };
-
-  // header
-  tbl.querySelector('thead').innerHTML = `<tr>${all.map(h=>`<th>${labels[h]||h}</th>`).join('')}</tr>`;
-
-  // body
-  tbl.querySelector('tbody').innerHTML = view.map(r=>{
-    return `<tr>
-        ${all.map(h=>{
-          let val = r[h] ?? '';
-          if(h==='__score') val = `<span class="score">${val}</span>`;
-          if(h==='__li' && val) val = `<a href="${val}" target="_blank">LinkedIn</a>`;
-          if(h==='__ats' && val) val = `<a href="${val}" target="_blank">Open in ATS</a>`;
-          if(h==='__reason') val = `<span class="small">${val}</span>`;
-          return `<td>${val}</td>`
-        }).join('')}
-      </tr>`
-  }).join('');
-}
-
-function exportCSV(){
-  if(!ranked.length) return;
-  const topN = Math.max(1, Number(el('topN').value||30));
-  const out = ranked.slice(0, topN).map(r=>({
-    Score:r.__score,
-    Name:r.__name,
-    LinkedIn:r.__li,
-    CandidateURL:r.__ats,
-    Why:r.__reason,
-    Skills:r['Skills']||'',
-    CurrentPosition:r['Current position']||'',
-    PastPosition:r['Past position']||'',
-    EducationLevel:r['Education level']||'',
-    Degree:r['Degree']||''
-  }));
-  const csv = Papa.unparse(out);
-  const blob = new Blob([csv], {type:'text/csv;charset=utf-8;'});
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url; a.download = `ranked_candidates_${new Date().toISOString().slice(0,10)}.csv`;
-  document.body.appendChild(a); a.click(); document.body.removeChild(a);
-  URL.revokeObjectURL(url);
-}
-
-if(rankBtn) rankBtn.addEventListener('click', ()=> rank(false));
-if(previewBtn) previewBtn.addEventListener('click', ()=> rank(true));
-if(exportBtn) exportBtn.addEventListener('click', exportCSV);
-
+// Expose for Node tests and browser usage
 if (typeof module !== 'undefined') {
-  module.exports = { groups, saveGroups, renderGroupsUI, scoreRow };
+  module.exports = { groups, saveGroups, scoreRow };
 }
+
+if (typeof window !== 'undefined') {
+  window.main = { groups, saveGroups, scoreRow };
+}
+


### PR DESCRIPTION
## Summary
- Replace vanilla DOM UI with a new React front-end rendered via CDN.
- Extract scoring and group persistence logic into a DOM-free module.
- Document lightweight React workflow and testing approach.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a638b3135c832fa1241c0e19b1ce7b