### PR TITLE
Add job description group generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,12 @@
       </div>
 
       <div class="section">
+        <label>Job Description</label>
+        <textarea id="jobDesc" style="width:100%; height:80px" placeholder="Paste job description"></textarea>
+        <button class="btn alt" id="genFromDesc" style="margin-top:8px">Generate Groups</button>
+      </div>
+
+      <div class="section">
         <div style="display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin-bottom:10px">
           <span class="pill">Preset: <button class="btn alt" id="presetNet">Favor .NET</button> <button class="btn alt" id="presetBalanced">Balanced</button></span>
           <span class="small">Adjust sliders to change scoring weights. Total score is the sum of matched keyword groups.</span>

--- a/main.js
+++ b/main.js
@@ -20,8 +20,26 @@ if (!groups.length) {
   saveGroups();
 }
 
+const STOP_WORDS = new Set('a an and are as at be by for from in is it of on or the to with your you our we this that'.split(' '));
+const DEFAULT_GENERATED_WEIGHT = 2;
+const GEN_TOP_N = 8;
+
 function saveGroups(){
   localStorage.setItem('groups', JSON.stringify(groups));
+}
+
+function generateGroupsFromDesc(desc){
+  const tokens = (desc.toLowerCase().match(/[a-z0-9+.#]+/g) || []).filter(t => !STOP_WORDS.has(t));
+  const counts = {};
+  tokens.forEach(t => counts[t] = (counts[t]||0)+1);
+  const topTokens = Object.entries(counts)
+    .sort((a,b)=> b[1]-a[1])
+    .slice(0, GEN_TOP_N)
+    .map(([tok])=>({ label:tok, patterns:[tok], weight:DEFAULT_GENERATED_WEIGHT }));
+  groups.length = 0;
+  groups.push(...topTokens);
+  renderGroupsUI();
+  saveGroups();
 }
 
 const el = id => typeof document !== 'undefined' ? document.getElementById(id) : null;
@@ -33,6 +51,9 @@ const statusEl = el('status');
 const tableWrap = el('tableWrap');
 const resultCount = el('resultCount');
 const filterInput = el('filterInput');
+
+const jobDescEl = el('jobDesc');
+const genFromDescBtn = el('genFromDesc');
 
 const colName = el('colName');
 const colLinkedIn = el('colLinkedIn');
@@ -75,6 +96,10 @@ if(addGroupBtn) addGroupBtn.addEventListener('click',()=>{
   groups.push({ label:'', patterns:[], weight:0 });
   renderGroupsUI();
   saveGroups();
+});
+
+if(genFromDescBtn) genFromDescBtn.addEventListener('click',()=>{
+  generateGroupsFromDesc(jobDescEl.value || '');
 });
 
 // Presets
@@ -253,5 +278,5 @@ if(filterInput) filterInput.addEventListener('input', () => {
 });
 
 if (typeof module !== 'undefined') {
-  module.exports = { groups, saveGroups, renderGroupsUI, scoreRow };
+  module.exports = { groups, saveGroups, renderGroupsUI, scoreRow, generateGroupsFromDesc };
 }

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -35,3 +35,15 @@ test('saveGroups persists changes', () => {
   const stored = JSON.parse(global.localStorage.getItem('groups'));
   assert.strictEqual(stored.length, initial + 1);
 });
+
+test('generateGroupsFromDesc builds groups from job description', () => {
+  const main = setup();
+  main.generateGroupsFromDesc('java Java AWS c# aws python');
+  assert.strictEqual(main.groups.length, 4);
+  const labels = main.groups.map(g=>g.label).sort();
+  assert.deepStrictEqual(labels, ['aws','c#','java','python']);
+  main.groups.forEach(g=>{
+    assert.deepStrictEqual(g.patterns, [g.label]);
+    assert.strictEqual(g.weight, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- Allow pasting a job description and generating keyword groups
- Parse description text into top tokens to build default-weight groups
- Wire up button and tests for new generation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a78c314e08832f9777acb708609b92