### PR TITLE
Generate keyword groups on demand

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,14 +50,17 @@
       </div>
 
       <div class="section">
-        <div style="display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin-bottom:10px">
-          <span class="pill">Preset: <button class="btn alt" id="presetNet">Favor .NET</button> <button class="btn alt" id="presetBalanced">Balanced</button></span>
-          <span class="small">Adjust sliders to change scoring weights. Total score is the sum of matched keyword groups.</span>
+        <button class="btn alt" id="generateGroups">Generate Groups</button>
+        <div id="groupsArea" style="display:none">
+          <div style="display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin-bottom:10px">
+            <span class="pill">Preset: <button class="btn alt" id="presetNet">Favor .NET</button> <button class="btn alt" id="presetBalanced">Balanced</button></span>
+            <span class="small">Adjust sliders to change scoring weights. Total score is the sum of matched keyword groups.</span>
+          </div>
+          <div class="weights" id="weights">
+            <!-- sliders injected here -->
+          </div>
+          <button class="btn alt" id="addGroup" style="margin-top:10px">Add Group</button>
         </div>
-        <div class="weights" id="weights">
-          <!-- sliders injected here -->
-        </div>
-        <button class="btn alt" id="addGroup" style="margin-top:10px">Add Group</button>
       </div>
 
       <div class="section" style="display:flex; gap:10px; flex-wrap:wrap">

--- a/main.js
+++ b/main.js
@@ -12,14 +12,11 @@ const DEFAULT_GROUPS = [
 ];
 
 let groups = [];
-try {
-  groups = JSON.parse(localStorage.getItem('groups') || '[]');
-} catch(e) { groups = []; }
-if (!groups.length) {
-  groups = JSON.parse(JSON.stringify(DEFAULT_GROUPS));
-  saveGroups();
+function loadGroups(){
+  try {
+    groups = JSON.parse(localStorage.getItem('groups') || '[]');
+  } catch(e) { groups = []; }
 }
-
 function saveGroups(){
   localStorage.setItem('groups', JSON.stringify(groups));
 }
@@ -45,6 +42,9 @@ let ranked = [];       // ranked rows with score & reason
 
 // Build group UI
 const weightsWrap = el('weights');
+const groupsArea = el('groupsArea');
+const generateGroupsBtn = el('generateGroups');
+
 function renderGroupsUI(){
   if(!weightsWrap) return;
   weightsWrap.innerHTML = '';
@@ -69,7 +69,17 @@ function renderGroupsUI(){
     block.querySelector('.remove').addEventListener('click',()=>{ groups.splice(i,1); renderGroupsUI(); saveGroups(); });
   });
 }
-renderGroupsUI();
+
+if(generateGroupsBtn) generateGroupsBtn.addEventListener('click', ()=>{
+  loadGroups();
+  if(!groups.length){
+    groups = JSON.parse(JSON.stringify(DEFAULT_GROUPS));
+    saveGroups();
+  }
+  if(groupsArea) groupsArea.style.display = 'block';
+  generateGroupsBtn.style.display = 'none';
+  renderGroupsUI();
+});
 const addGroupBtn = el('addGroup');
 if(addGroupBtn) addGroupBtn.addEventListener('click',()=>{
   groups.push({ label:'', patterns:[], weight:0 });


### PR DESCRIPTION
## Summary
- Hide keyword groups by default and add a **Generate Groups** button to reveal them
- Load saved groups or default groups only when requested, keeping rankings empty until groups are generated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acd1a027b0832fbfdf5ac697739a62