### PR TITLE
Generate keyword groups on job description paste

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,14 +50,21 @@
       </div>
 
       <div class="section">
-        <div style="display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin-bottom:10px">
-          <span class="pill">Preset: <button class="btn alt" id="presetNet">Favor .NET</button> <button class="btn alt" id="presetBalanced">Balanced</button></span>
-          <span class="small">Adjust sliders to change scoring weights. Total score is the sum of matched keyword groups.</span>
+        <label>Job Description</label>
+        <textarea id="jobDesc" placeholder="Paste job description here" rows="6"></textarea>
+      </div>
+
+      <div class="section">
+        <div id="groupsArea" style="display:none">
+          <div style="display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin-bottom:10px">
+            <span class="pill">Preset: <button class="btn alt" id="presetNet">Favor .NET</button> <button class="btn alt" id="presetBalanced">Balanced</button></span>
+            <span class="small">Adjust sliders to change scoring weights. Total score is the sum of matched keyword groups.</span>
+          </div>
+          <div class="weights" id="weights">
+            <!-- sliders injected here -->
+          </div>
+          <button class="btn alt" id="addGroup" style="margin-top:10px">Add Group</button>
         </div>
-        <div class="weights" id="weights">
-          <!-- sliders injected here -->
-        </div>
-        <button class="btn alt" id="addGroup" style="margin-top:10px">Add Group</button>
       </div>
 
       <div class="section" style="display:flex; gap:10px; flex-wrap:wrap">

--- a/main.js
+++ b/main.js
@@ -12,14 +12,11 @@ const DEFAULT_GROUPS = [
 ];
 
 let groups = [];
-try {
-  groups = JSON.parse(localStorage.getItem('groups') || '[]');
-} catch(e) { groups = []; }
-if (!groups.length) {
-  groups = JSON.parse(JSON.stringify(DEFAULT_GROUPS));
-  saveGroups();
+function loadGroups(){
+  try {
+    groups = JSON.parse(localStorage.getItem('groups') || '[]');
+  } catch(e) { groups = []; }
 }
-
 function saveGroups(){
   localStorage.setItem('groups', JSON.stringify(groups));
 }
@@ -45,6 +42,10 @@ let ranked = [];       // ranked rows with score & reason
 
 // Build group UI
 const weightsWrap = el('weights');
+const groupsArea = el('groupsArea');
+const jobDesc = el('jobDesc');
+let groupsInitialized = false;
+
 function renderGroupsUI(){
   if(!weightsWrap) return;
   weightsWrap.innerHTML = '';
@@ -69,7 +70,20 @@ function renderGroupsUI(){
     block.querySelector('.remove').addEventListener('click',()=>{ groups.splice(i,1); renderGroupsUI(); saveGroups(); });
   });
 }
-renderGroupsUI();
+
+if(jobDesc) jobDesc.addEventListener('paste', ()=>{
+  if(groupsInitialized) return;
+  setTimeout(()=>{
+    loadGroups();
+    if(!groups.length){
+      groups = JSON.parse(JSON.stringify(DEFAULT_GROUPS));
+      saveGroups();
+    }
+    if(groupsArea) groupsArea.style.display = 'block';
+    renderGroupsUI();
+    groupsInitialized = true;
+  },0);
+});
 const addGroupBtn = el('addGroup');
 if(addGroupBtn) addGroupBtn.addEventListener('click',()=>{
   groups.push({ label:'', patterns:[], weight:0 });


### PR DESCRIPTION
## Summary
- Add a job description textarea
- Initialize keyword groups only once when the job description is pasted and reveal the group editor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acd1a027b0832fbfdf5ac697739a62