### PR TITLE
Convert Candidate Ranker UI to React

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,91 +4,15 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Candidate Ranker – HR Friendly</title>
+  <!-- React and ReactDOM from CDN -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <!-- Papa Parse for CSV parsing -->
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div class="wrap">
-    <h1>Candidate Ranker <span class="badge">HR Friendly</span></h1>
-    <div class="sub">Upload a candidate CSV, set weights, and export a ranked Top N. Runs 100% in your browser (no server).</div>
-
-    <div class="card">
-      <div class="section row">
-        <div>
-          <label>Upload CSV (export from Comeet / ATS)</label>
-          <input id="file" type="file" accept=".csv" />
-          <div class="small" style="margin-top:8px">Detected columns will appear below so you can map them.</div>
-        </div>
-        <div>
-          <label>Top N to keep</label>
-          <input id="topN" type="number" min="1" value="30" />
-          <div class="small">Default is 30</div>
-        </div>
-      </div>
-
-      <div class="section">
-        <div class="grid">
-          <div>
-            <label>Column: <b>Name</b></label>
-            <select id="colName"></select>
-          </div>
-          <div>
-            <label>Column: <b>LinkedIn URL</b></label>
-            <select id="colLinkedIn"></select>
-          </div>
-          <div>
-            <label>Column: <b>ATS Candidate URL</b></label>
-            <select id="colATS"></select>
-          </div>
-          <div>
-            <label>Column(s) scanned for keywords (hold <span class="kbd">Ctrl</span> to select multiple)</label>
-            <select id="colScan" multiple size="6"></select>
-            <div class="small">Tip: include <i>Skills</i>, <i>Current position</i>, <i>Past position</i>, <i>Education level</i>, <i>Degree</i>.</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="section">
-        <label>Job Description</label>
-        <textarea id="jobDesc" placeholder="Paste job description here" rows="6"></textarea>
-      </div>
-
-      <div class="section">
-        <div id="groupsArea" style="display:none">
-          <div style="display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin-bottom:10px">
-            <span class="pill">Preset: <button class="btn alt" id="presetNet">Favor .NET</button> <button class="btn alt" id="presetBalanced">Balanced</button></span>
-            <span class="small">Adjust sliders to change scoring weights. Total score is the sum of matched keyword groups.</span>
-          </div>
-          <div class="weights" id="weights">
-            <!-- sliders injected here -->
-          </div>
-          <button class="btn alt" id="addGroup" style="margin-top:10px">Add Group</button>
-        </div>
-      </div>
-
-      <div class="section" style="display:flex; gap:10px; flex-wrap:wrap">
-        <button class="btn" id="rankBtn">Rank Candidates</button>
-        <button class="btn alt" id="previewBtn">Preview 10</button>
-        <button class="btn warn" id="exportBtn" disabled>Export Ranked CSV</button>
-        <span class="small" id="status"></span>
-      </div>
-
-      <div class="section" id="tableWrap" style="display:none">
-        <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px">
-          <div class="pill"><span>Results</span> <span id="resultCount"></span></div>
-          <div class="small">Sorted by <b>Score</b> desc. Click column headers to sort locally.</div>
-        </div>
-        <input id="filterInput" type="text" placeholder="Filter results" style="margin-bottom:10px; width:100%" />
-        <div style="overflow:auto; max-height:60vh">
-          <table id="tbl"><thead></thead><tbody></tbody></table>
-        </div>
-      </div>
-    </div>
-
-    <p class="small muted" style="margin-top:14px">CSV never leaves your machine. Scoring is keyword-based and explainable. Edit weights to match your criteria.</p>
-  </div>
-
-<script src="main.js"></script>
+  <div id="root"></div>
+  <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,271 +1,189 @@
-// --- Keyword groups & default weights ---
-const DEFAULT_GROUPS = [
-  { key:"dotnet", label:".NET stack (.NET, C#, ASP.NET)", patterns:[".net","c#","asp.net","aspnet","entity framework","ef core"], weight:8 },
-  { key:"java", label:"Java stack (Java, Spring)", patterns:[" java ","spring","spring boot"], weight:2 },
-  { key:"micro", label:"Microservices", patterns:["microservice","micro-services","micro services"], weight:3 },
-  { key:"db", label:"Databases (SQL/NoSQL)", patterns:[" sql ","database","postgres","mysql","mssql","nosql","mongodb","cosmos","dynamodb"], weight:2 },
-  { key:"fe", label:"Front-end (React/Angular/Vue)", patterns:["react","angular","vue"], weight:2 },
-  { key:"devops", label:"CI/CD & Tools (Bitbucket/Jenkins/Pipelines)", patterns:["bitbucket","jenkins","pipeline","ci/cd","cicd","github actions","azure devops"], weight:2 },
-  { key:"cloud", label:"Cloud & Messaging (AWS/Azure/RabbitMQ/Couchbase)", patterns:["aws","azure","gcp","cloud","rabbitmq","couchbase","sqs","sns","kafka"], weight:2 },
-  { key:"support", label:"Support & Debugging", patterns:["support","tier-3","tier3","debug","troubleshoot","incident"], weight:2 },
-  { key:"edu", label:"Education (Bachelor/CS)", patterns:["bachelor","b.sc","bsc","computer science","b.tech","btech"], weight:2 },
+// React-based Candidate Ranker
+
+if (typeof window === 'undefined') {
+  globalThis.window = {};
+}
+
+window.DEFAULT_GROUPS = [
+  { key: "dotnet", label: ".NET stack (.NET, C#, ASP.NET)", patterns: [".net", "c#", "asp.net", "aspnet", "entity framework", "ef core"], weight: 8 },
+  { key: "java", label: "Java stack (Java, Spring)", patterns: [" java ", "spring", "spring boot"], weight: 2 },
+  { key: "micro", label: "Microservices", patterns: ["microservice", "micro-services", "micro services"], weight: 3 },
+  { key: "db", label: "Databases (SQL/NoSQL)", patterns: [" sql ", "database", "postgres", "mysql", "mssql", "nosql", "mongodb", "cosmos", "dynamodb"], weight: 2 },
+  { key: "fe", label: "Front-end (React/Angular/Vue)", patterns: ["react", "angular", "vue"], weight: 2 },
+  { key: "devops", label: "CI/CD & Tools (Bitbucket/Jenkins/Pipelines)", patterns: ["bitbucket", "jenkins", "pipeline", "ci/cd", "cicd", "github actions", "azure devops"], weight: 2 },
+  { key: "cloud", label: "Cloud & Messaging (AWS/Azure/RabbitMQ/Couchbase)", patterns: ["aws", "azure", "gcp", "cloud", "rabbitmq", "couchbase", "sqs", "sns", "kafka"], weight: 2 },
+  { key: "support", label: "Support & Debugging", patterns: ["support", "tier-3", "tier3", "debug", "troubleshoot", "incident"], weight: 2 },
+  { key: "edu", label: "Education (Bachelor/CS)", patterns: ["bachelor", "b.sc", "bsc", "computer science", "b.tech", "btech"], weight: 2 },
 ];
 
 let groups = [];
-function loadGroups(){
+
+function loadGroups() {
   try {
     groups = JSON.parse(localStorage.getItem('groups') || '[]');
-  } catch(e) { groups = []; }
+  } catch (e) {
+    groups = [];
+  }
+  if (!groups.length) {
+    groups = JSON.parse(JSON.stringify(window.DEFAULT_GROUPS));
+    saveGroups();
+  }
 }
-function saveGroups(){
+
+function saveGroups() {
   localStorage.setItem('groups', JSON.stringify(groups));
 }
 
-const el = id => typeof document !== 'undefined' ? document.getElementById(id) : null;
-const fileEl = el('file');
-const rankBtn = el('rankBtn');
-const previewBtn = el('previewBtn');
-const exportBtn = el('exportBtn');
-const statusEl = el('status');
-const tableWrap = el('tableWrap');
-const resultCount = el('resultCount');
-const filterInput = el('filterInput');
-
-const colName = el('colName');
-const colLinkedIn = el('colLinkedIn');
-const colATS = el('colATS');
-const colScan = el('colScan');
-
-let rows = [];         // raw records
-let headers = [];      // csv headers
-let ranked = [];       // ranked rows with score & reason
-
-// Build group UI
-const weightsWrap = el('weights');
-const groupsArea = el('groupsArea');
-const jobDesc = el('jobDesc');
-let groupsInitialized = false;
-
-function renderGroupsUI(){
-  if(!weightsWrap) return;
-  weightsWrap.innerHTML = '';
-  groups.forEach((g,i)=>{
-    const block = document.createElement('div');
-    block.className = 'group-card card section';
-    block.innerHTML = `
-        <input type="text" class="grp-label" placeholder="Label" value="${g.label}">
-        <input type="text" class="grp-patterns" placeholder="pattern1, pattern2" value="${g.patterns.join(', ')}">
-        <input type="range" class="grp-weight" min="0" max="12" step="1" value="${g.weight}">
-        <div class="small">Weight: <span class="badge">${g.weight}</span></div>
-        <button class="btn warn remove">Remove</button>
-      `;
-    weightsWrap.appendChild(block);
-    const labelInput = block.querySelector('.grp-label');
-    labelInput.addEventListener('input',()=>{ g.label = labelInput.value; saveGroups(); });
-    const patternsInput = block.querySelector('.grp-patterns');
-    patternsInput.addEventListener('input',()=>{ g.patterns = patternsInput.value.split(',').map(p=>p.trim().toLowerCase()).filter(Boolean); saveGroups(); });
-    const slider = block.querySelector('.grp-weight');
-    const out = block.querySelector('.badge');
-    slider.addEventListener('input',()=>{ g.weight = Number(slider.value); out.textContent = slider.value; saveGroups(); });
-    block.querySelector('.remove').addEventListener('click',()=>{ groups.splice(i,1); renderGroupsUI(); saveGroups(); });
-  });
+function makeTextBlob(r, scanCols) {
+  const parts = scanCols.map((c) => String(r[c] || ''));
+  return (' ' + parts.join(' ') + ' ').toLowerCase();
 }
 
-if(jobDesc) jobDesc.addEventListener('paste', ()=>{
-  if(groupsInitialized) return;
-  setTimeout(()=>{
-    loadGroups();
-    if(!groups.length){
-      groups = JSON.parse(JSON.stringify(DEFAULT_GROUPS));
-      saveGroups();
+function scoreRow(r, textOverride, scanCols = []) {
+  const text = textOverride ?? makeTextBlob(r, scanCols);
+  let score = 0;
+  const hits = [];
+  groups.forEach((g) => {
+    const matched = g.patterns.some((p) => text.includes(p));
+    if (matched) {
+      score += g.weight;
+      hits.push(g.label);
     }
-    if(groupsArea) groupsArea.style.display = 'block';
-    renderGroupsUI();
-    groupsInitialized = true;
-  },0);
-});
-const addGroupBtn = el('addGroup');
-if(addGroupBtn) addGroupBtn.addEventListener('click',()=>{
-  groups.push({ label:'', patterns:[], weight:0 });
-  renderGroupsUI();
-  saveGroups();
-});
-
-// Presets
-const presetNetBtn = el('presetNet');
-if(presetNetBtn) presetNetBtn.addEventListener('click',()=>{
-  groups.find(g=>g.key==='dotnet').weight = 10;
-  groups.find(g=>g.key==='java').weight = 2;
-  groups.find(g=>g.key==='micro').weight = 3;
-  groups.find(g=>g.key==='db').weight = 3;
-  groups.find(g=>g.key==='fe').weight = 2;
-  groups.find(g=>g.key==='devops').weight = 2;
-  groups.find(g=>g.key==='cloud').weight = 3;
-  groups.find(g=>g.key==='support').weight = 3;
-  groups.find(g=>g.key==='edu').weight = 2;
-  renderGroupsUI();
-  saveGroups();
-});
-const presetBalancedBtn = el('presetBalanced');
-if(presetBalancedBtn) presetBalancedBtn.addEventListener('click',()=>{
-  groups.forEach(g=> g.weight = {dotnet:8, java:3, micro:3, db:2, fe:2, devops:2, cloud:2, support:2, edu:2}[g.key] || 2);
-  renderGroupsUI();
-  saveGroups();
-});
-
-function guessMapping() {
-  const opts = headers.map(h=>`<option>${h}</option>`).join('');
-  [colName, colLinkedIn, colATS, colScan].forEach(sel=> sel.innerHTML = opts);
-
-  function selectIfContains(selectEl, substrings){
-    substrings = substrings.map(s=>s.toLowerCase());
-    const idx = headers.findIndex(h=> substrings.some(s=> h.toLowerCase().includes(s)));
-    if(idx>=0) selectEl.selectedIndex = idx;
-  }
-
-  selectIfContains(colName,["name"]);
-  selectIfContains(colLinkedIn,["linkedin"]);
-  selectIfContains(colATS,["candidate url","ats","comeet","url"]);
-
-  // Multi select defaults for scanning
-  const scanLikely = ["skills","current position","past position","education","degree","languages"];
-  Array.from(colScan.options).forEach(opt=>{
-    if (scanLikely.some(s=> opt.value.toLowerCase().includes(s))) opt.selected = true;
-  });
-}
-
-if(fileEl) fileEl.addEventListener('change', (e)=>{
-  const f = e.target.files?.[0];
-  if(!f) return;
-  statusEl.textContent = 'Parsing…';
-  Papa.parse(f, {
-    header:true,
-    skipEmptyLines:true,
-    complete: (res)=>{
-      rows = res.data;
-      headers = res.meta.fields || Object.keys(rows[0]||{});
-      guessMapping();
-      tableWrap.style.display='none';
-      exportBtn.disabled = true;
-      statusEl.textContent = `Loaded ${rows.length} rows · ${headers.length} columns`;
-    },
-    error: (err)=>{
-      statusEl.textContent = 'Parse error: '+err;
-    }
-  })
-});
-
-function getSelectedScanColumns(){
-  return Array.from(colScan.selectedOptions).map(o=>o.value);
-}
-
-function makeTextBlob(r){
-  const scanCols = getSelectedScanColumns();
-  const parts = scanCols.map(c=> String(r[c]||''));
-  return (' '+parts.join(' ')+' ').toLowerCase(); // padded for exact-ish word checks
-}
-
-function scoreRow(r, textOverride){
-  const text = textOverride ?? makeTextBlob(r);
-  let score = 0; const hits=[];
-  groups.forEach(g=>{
-    const matched = g.patterns.some(p=> text.includes(p));
-    if(matched){ score += g.weight; hits.push(g.label); }
   });
   return { score, reason: hits.join(' · ') };
 }
 
-function rank(topOnly=false){
-  if(!rows.length){ statusEl.textContent = 'Please upload a CSV first.'; return; }
-  const nameCol = colName.value; const liCol = colLinkedIn.value; const atsCol = colATS.value;
+if (typeof window !== 'undefined' && window.React && window.ReactDOM) {
+  const { useState, useEffect } = window.React;
 
-  ranked = rows.map(r=>{
-    const {score, reason} = scoreRow(r);
-    return { ...r, __score:score, __reason:reason, __name:r[nameCol]||'', __li:r[liCol]||'', __ats:r[atsCol]||'' };
-  }).sort((a,b)=> b.__score - a.__score);
-
-  const topN = Math.max(1, Number(el('topN').value||30));
-  const view = topOnly ? ranked.slice(0,10) : ranked.slice(0, topN);
-  renderTable(view);
-
-  resultCount.textContent = `${view.length} shown (Top ${topOnly?10:topN}) of ${rows.length}`;
-  tableWrap.style.display='block';
-  exportBtn.disabled = false;
-  if(filterInput && filterInput.value){
-    filterInput.dispatchEvent(new Event('input'));
+  function GroupCard({ group, onChange, onRemove }) {
+    return window.React.createElement(
+      'div',
+      { className: 'group-card card section' },
+      [
+        window.React.createElement('input', {
+          key: 'label',
+          type: 'text',
+          className: 'grp-label',
+          placeholder: 'Label',
+          value: group.label,
+          onInput: (e) => onChange({ ...group, label: e.target.value }),
+        }),
+        window.React.createElement('input', {
+          key: 'patterns',
+          type: 'text',
+          className: 'grp-patterns',
+          placeholder: 'pattern1, pattern2',
+          value: group.patterns.join(', '),
+          onInput: (e) =>
+            onChange({
+              ...group,
+              patterns: e.target.value
+                .split(',')
+                .map((p) => p.trim().toLowerCase())
+                .filter(Boolean),
+            }),
+        }),
+        window.React.createElement('input', {
+          key: 'weight',
+          type: 'range',
+          className: 'grp-weight',
+          min: 0,
+          max: 12,
+          step: 1,
+          value: group.weight,
+          onInput: (e) => onChange({ ...group, weight: Number(e.target.value) }),
+        }),
+        window.React.createElement(
+          'div',
+          { key: 'out', className: 'small' },
+          'Weight: ',
+          window.React.createElement('span', { className: 'badge' }, group.weight)
+        ),
+        window.React.createElement(
+          'button',
+          { key: 'remove', className: 'btn warn remove', onClick: onRemove },
+          'Remove'
+        ),
+      ]
+    );
   }
-}
 
-function renderTable(view){
-  const tbl = el('tbl');
-  const cols = ["__score","__name","__li","__ats","__reason"]; // always show these
-  // plus add a couple of helpful columns if they exist
-  const extras = ["Skills","Current position","Past position","Education level","Degree"].filter(h=> headers.includes(h));
-  const all = [...cols, ...extras];
+  function App() {
+    const [groupState, setGroupState] = useState([]);
 
-  const labels = {
-    "__score":"Score", "__name":"Name", "__li":"LinkedIn", "__ats":"Candidate URL", "__reason":"Why (matched keywords)"
-  };
+    useEffect(() => {
+      loadGroups();
+      setGroupState([...groups]);
+    }, []);
 
-  // header
-  tbl.querySelector('thead').innerHTML = `<tr>${all.map(h=>`<th>${labels[h]||h}</th>`).join('')}</tr>`;
+    useEffect(() => {
+      groups = groupState;
+      saveGroups();
+    }, [groupState]);
 
-  // body
-  tbl.querySelector('tbody').innerHTML = view.map(r=>{
-    return `<tr>
-        ${all.map(h=>{
-          let val = r[h] ?? '';
-          if(h==='__score') val = `<span class="score">${val}</span>`;
-          if(h==='__li' && val) val = `<a href="${val}" target="_blank">LinkedIn</a>`;
-          if(h==='__ats' && val) val = `<a href="${val}" target="_blank">Open in ATS</a>`;
-          if(h==='__reason') val = `<span class="small">${val}</span>`;
-          return `<td>${val}</td>`
-        }).join('')}
-      </tr>`
-  }).join('');
-}
+    const addGroup = () =>
+      setGroupState([...groupState, { label: '', patterns: [], weight: 0 }]);
 
-function exportCSV(){
-  if(!ranked.length) return;
-  const topN = Math.max(1, Number(el('topN').value||30));
-  const out = ranked.slice(0, topN).map(r=>({
-    Score:r.__score,
-    Name:r.__name,
-    LinkedIn:r.__li,
-    CandidateURL:r.__ats,
-    Why:r.__reason,
-    Skills:r['Skills']||'',
-    CurrentPosition:r['Current position']||'',
-    PastPosition:r['Past position']||'',
-    EducationLevel:r['Education level']||'',
-    Degree:r['Degree']||''
-  }));
-  const csv = Papa.unparse(out);
-  const blob = new Blob([csv], {type:'text/csv;charset=utf-8;'});
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url; a.download = `ranked_candidates_${new Date().toISOString().slice(0,10)}.csv`;
-  document.body.appendChild(a); a.click(); document.body.removeChild(a);
-  URL.revokeObjectURL(url);
-}
+    return window.React.createElement(
+      'div',
+      { className: 'wrap' },
+      [
+        window.React.createElement(
+          'h1',
+          { key: 'h1' },
+          'Candidate Ranker ',
+          window.React.createElement('span', { className: 'badge' }, 'HR Friendly')
+        ),
+        window.React.createElement(
+          'div',
+          { key: 'groups', className: 'section' },
+          [
+            window.React.createElement(
+              'div',
+              { key: 'groupsArea', id: 'groupsArea' },
+              [
+                window.React.createElement(
+                  'div',
+                  { key: 'weights', className: 'weights' },
+                  groupState.map((g, i) =>
+                    window.React.createElement(GroupCard, {
+                      key: i,
+                      group: g,
+                      onChange: (ng) => {
+                        const arr = [...groupState];
+                        arr[i] = ng;
+                        setGroupState(arr);
+                      },
+                      onRemove: () => {
+                        const arr = [...groupState];
+                        arr.splice(i, 1);
+                        setGroupState(arr);
+                      },
+                    })
+                  )
+                ),
+                window.React.createElement(
+                  'button',
+                  { className: 'btn alt', onClick: addGroup, style: { marginTop: '10px' } },
+                  'Add Group'
+                ),
+              ]
+            ),
+          ]
+        ),
+      ]
+    );
+  }
 
-if(rankBtn) rankBtn.addEventListener('click', ()=> rank(false));
-if(previewBtn) previewBtn.addEventListener('click', ()=> rank(true));
-if(exportBtn) exportBtn.addEventListener('click', exportCSV);
-
-if(filterInput) filterInput.addEventListener('input', () => {
-  if(!ranked.length){ return; }
-  const q = filterInput.value.trim().toLowerCase();
-  const filtered = ranked.filter(r => {
-    if(!q) return true;
-    const name = String(r.__name || '').toLowerCase();
-    const text = makeTextBlob(r);
-    return name.includes(q) || text.includes(q);
+  window.addEventListener('DOMContentLoaded', () => {
+    const root = document.getElementById('root');
+    if (root) {
+      window.ReactDOM.createRoot(root).render(window.React.createElement(App));
+    }
   });
-  renderTable(filtered);
-  resultCount.textContent = `${filtered.length} shown of ${ranked.length}`;
-});
+}
 
 if (typeof module !== 'undefined') {
-  module.exports = { groups, saveGroups, renderGroupsUI, scoreRow };
+  module.exports = { groups, saveGroups, scoreRow, DEFAULT_GROUPS: window.DEFAULT_GROUPS };
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "node --test"
   },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- Replace static HTML with React root and CDN React/ReactDOM scripts
- Reimplement group editor as React components while keeping scoring API
- Add React and ReactDOM dependencies

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68afc802bdac832fa54b11c76f3fe066